### PR TITLE
[PARSE] 천장과 바닥 색깔이 [0, 255] 범위를 벗어나도 정상 실행되는 이슈 #5

### DIFF
--- a/src/execute_cub3d/utils8.c
+++ b/src/execute_cub3d/utils8.c
@@ -12,6 +12,20 @@
 
 #include "../../cub3d.h"
 
+static int check_color_range(char *color_string)
+{
+	int	rgb;
+
+	if (!color_string)
+		return (FALSE);
+	else if (ft_strlen(color_string) > 4)
+		return (FALSE);
+	rgb = ft_atoi(color_string);
+	if (rgb < 0 || 255 < rgb)
+		return (FALSE);
+	return (TRUE);
+}
+
 static int	check_seperator(char *color_string)
 {
 	int	i;
@@ -39,6 +53,8 @@ static int	check_array_number(char **array)
 	count = 0;
 	while (array[count] != NULL)
 	{
+		if (check_color_range(array[count]) == FALSE)
+			return (FALSE);
 		++count;
 	}
 	if (count != 3)

--- a/src/load_file/utils4.c
+++ b/src/load_file/utils4.c
@@ -48,6 +48,7 @@ void	set_map_width_height(t_map *map_info, int fd)
 	int		empty_line_flag;
 
 	line = skip_empty_line(fd);
+	empty_line_flag = FALSE;
 	while (TRUE)
 	{
 		if (line == NULL)


### PR DESCRIPTION
## 작업내용

- 천장이나 바닥 (F, C) 에 해당하는 색깔이 서브젝트에서 지정된 범위인 [0, 255] 밖의 값이어도 실행되는 이슈가 있어 create_trgb() 함수 내부에서 새로 추가한 check_color_range() 함수를 사용해 값을 확인한 후 rgb 값을 반환하도록 변경했습니다.

#5 