### PR TITLE
[PARSE] FIX: F, C의 rgb color 값 중 마지막 b 값이 없을 때 정상 실행되는 이슈 #7

### DIFF
--- a/src/execute_cub3d/utils8.c
+++ b/src/execute_cub3d/utils8.c
@@ -18,6 +18,8 @@ static int	check_color_range(char *color_string)
 
 	if (!color_string)
 		return (FALSE);
+	else if (*color_string == '\n' || *color_string == '\0')
+		return (FALSE);
 	else if (ft_strlen(color_string) > 4)
 		return (FALSE);
 	rgb = ft_atoi(color_string);


### PR DESCRIPTION
## 작업내용

- check_color_range 에서 rgb값에 '127, 127,\n' 처럼 마지막 b 값이 존재하지 않고 개행문자만 존재할 경우, ft_atoi 에서 이를 0으로 판단하여 프로그램이 정상 실행되는 이슈가 있어 check_color_range 에서 개행문자만 존재할 경우 FALSE 를 반환하도록 함수에 if 문을 추가하였습니다.

#7 